### PR TITLE
Potential fix for code scanning alert no. 24: Missing CSRF middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -184,7 +184,8 @@
     "web3": "^4.13.0",
     "winston": "^3.16.0",
     "yaml-schema-validator": "^1.2.3",
-    "z85": "^0.0.2"
+    "z85": "^0.0.2",
+    "lusca": "^1.7.0"
   },
   "devDependencies": {
     "@cyclonedx/cyclonedx-npm": "^1.19.3",

--- a/server.ts
+++ b/server.ts
@@ -25,6 +25,7 @@ import config from 'config'
 import path from 'path'
 import morgan from 'morgan'
 import colors from 'colors/safe'
+import lusca from 'lusca'
 import * as utils from './lib/utils'
 import * as Prometheus from 'prom-client'
 import datacreator from './data/datacreator'
@@ -279,6 +280,7 @@ restoreOverwrittenFilesWithOriginals().then(() => {
 
   app.use(express.static(path.resolve('frontend/dist/frontend')))
   app.use(cookieParser('kekse'))
+  app.use(lusca.csrf())
   // vuln-code-snippet end directoryListingChallenge accessLogDisclosureChallenge
 
   /* Configure and enable backend-side i18n */


### PR DESCRIPTION
Potential fix for [https://github.com/muaazghazi/juice-shop/security/code-scanning/24](https://github.com/muaazghazi/juice-shop/security/code-scanning/24)

To fix the problem, we need to add CSRF protection middleware to the Express application. The `lusca` package is a well-known middleware for this purpose. We will install the `lusca` package and use its CSRF protection middleware in the application. This involves importing the `lusca` package and adding the `lusca.csrf()` middleware to the Express app configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
